### PR TITLE
Included task status in output of get-tasks command

### DIFF
--- a/commands/getTasks.js
+++ b/commands/getTasks.js
@@ -34,13 +34,16 @@ async function getTasks() {
     });
     response.results.forEach((page, index) => {
       //If it contains a title then print the task title and date due
-      //   console.log(page.properties);
       if (page.properties.Name.title.length > 0) {
+        const status = page.properties.Status.select.name;
         const taskName = page.properties.Name.title[0].text.content;
         const dueDate = formatDate(page.properties.Due.date.start);
         console.log(
           chalk.red.bold(++index + ": " + taskName) +
-            chalk.green.bold(" [Due: " + dueDate + "]")
+            " " +
+            chalk.blue.bold("[Status: " + status + "]") +
+            " " +
+            chalk.green.bold("[Due: " + dueDate + "]")
         );
       }
     });

--- a/index.js
+++ b/index.js
@@ -90,10 +90,3 @@ program.parse();
 // getSpecificPage("d4061b12-7573-42f2-aaf5-e642e45560bf");
 // updateTaskListPage("d4061b12-7573-42f2-aaf5-e642e45560bf");
 // updateSecificPage("93e095bb-41e9-4e52-b3a7-9c04ec74b3f9");
-
-//TODO Figure out how to add task lists
-/*
-notioncli get-tasks -> returns the list of pages in the task lists with various properties ex: Report Due (Nov 2) Status: To Do 
-notioncli create-task -> prompts user for various set of parameters. 1. Task name 2. Due Date (YYYY-MM-DD)
-notioncli update-task -> lists task -> user choose from the list by entering task number -> cli them prompts for which status 1.To Do 2. Doing 3. Done
-*/


### PR DESCRIPTION
This updated the 'get-tasks' command to include task status in the output